### PR TITLE
update macos-release version (3.1.0) dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"linux"
 	],
 	"dependencies": {
-		"macos-release": "^3.0.1",
+		"macos-release": "^3.1.0",
 		"windows-release": "^5.0.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Update macos-release to support MacOS Ventura