### PR TITLE
bump `windows-release` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	],
 	"dependencies": {
 		"macos-release": "^3.2.0",
-		"windows-release": "^6.0.0"
+		"windows-release": "^6.0.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.10.0",


### PR DESCRIPTION
Bump `windows-release` version to v6.0.1 to fix [fatal crash](https://github.com/sindresorhus/windows-release/issues/33) on calling `osName()` on Windows